### PR TITLE
add new tile type DROPDOWN

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "list": "cpp"
+  }
+}

--- a/include/classDropDown.h
+++ b/include/classDropDown.h
@@ -1,0 +1,32 @@
+﻿#pragma once
+#include <lvgl.h>
+#include <classTile.h>
+
+class classDropDown
+
+{
+private:
+  classTile* _callingTile = NULL;
+  lv_obj_t* _parent = NULL;
+  lv_obj_t* _ovlPanel2 = NULL;
+  lv_obj_t* _btnBack = NULL;
+  lv_obj_t* _btnUp = NULL;
+  lv_obj_t* _btnDown = NULL;
+  lv_obj_t* _label = NULL;
+  lv_obj_t* _dropDown = NULL;
+  lv_obj_t* _barLabel = NULL;
+
+public:
+  lv_obj_t* ovlPanel = NULL;
+
+  classDropDown(void){};
+  classDropDown(classTile* tile, lv_event_cb_t dropDownEventHandler);
+  void close(void);
+  void open(void);
+  classTile* getTile(void);
+
+  void setDropDownList(const char *list);
+  void setDropDownIndex(uint16_t index);
+  void setDropdDownLabel(const char* label);
+
+};

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -32,8 +32,10 @@ protected:
 
   void _button(lv_obj_t *parent, const void *img);
   void _reColorAll(lv_color_t color, lv_style_selector_t selector);
-  
-public : tileId_t tileId;
+  void _setIconTextFromIndex(void);
+
+public :
+  tileId_t tileId;
   lv_obj_t *btn = NULL;
 
   classTile(void){};

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -17,6 +17,7 @@ protected:
   lv_obj_t *_ovlPanel = NULL;
   lv_obj_t *_bar = NULL;
   lv_obj_t *_txtIconText = NULL;
+  lv_obj_t *_dropDown = NULL;
 
   int _screenIdx = 0;
   int _tileIdx = 0;
@@ -61,4 +62,8 @@ public : tileId_t tileId;
   int getLevel(void);
   void showOvlBar(int level);
   void addLevelControl(lv_event_cb_t downButtonCallBack, lv_event_cb_t upButtonCallBack);
+
+  void setDropDownList(const char *list);
+  void setSelectedItem(uint16_t index);
+  void addDropDown(lv_event_cb_t dropDownEventHandler);
 };

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -18,6 +18,8 @@ protected:
   lv_obj_t *_bar = NULL;
   lv_obj_t *_txtIconText = NULL;
   lv_obj_t *_dropDown = NULL;
+  lv_obj_t *_dropDownList = NULL;
+  lv_obj_t *_dropDownLabel = NULL;
 
   int _screenIdx = 0;
   int _tileIdx = 0;
@@ -26,6 +28,7 @@ protected:
   bool _state = false;
   int _level = 0;
   const void *_img = NULL;
+  uint16_t _dropDownIndex = 0;
 
   void _button(lv_obj_t *parent, const void *img);
   void _reColorAll(lv_color_t color, lv_style_selector_t selector);
@@ -64,6 +67,10 @@ public : tileId_t tileId;
   void addLevelControl(lv_event_cb_t downButtonCallBack, lv_event_cb_t upButtonCallBack);
 
   void setDropDownList(const char *list);
-  void setSelectedItem(uint16_t index);
-  void addDropDown(lv_event_cb_t dropDownEventHandler);
+  void setDropDownIndex(uint16_t index);
+  void setDropDownLabel(const char *label);
+  const char *getDropDownList(void);
+  uint16_t getDropDownIndex(void);
+  const char *getDropDownLabel(void);
+  void setDropDownIndicator(void);
 };

--- a/include/globalDefines.h
+++ b/include/globalDefines.h
@@ -7,6 +7,7 @@ enum tileType_t
   BLIND,
   COFFEE,
   DOOR,
+  DROPDOWN,
   LIGHT,
   NUMBER,
   ONOFF,

--- a/include/globalDefines.h
+++ b/include/globalDefines.h
@@ -23,6 +23,9 @@ enum tileType_t
 #define WP_OPA_BG_ON      255
 #define WP_OPA_BG_PRESSED 128
 
+#define SCREEN_WIDTH      320
+#define SCREEN_HEIGHT     480
+
 #define SCREEN_START      1
 #define SCREEN_END        8
 #define SCREEN_HOME       SCREEN_START

--- a/src/classes/classDropDown.cpp
+++ b/src/classes/classDropDown.cpp
@@ -40,18 +40,22 @@ classDropDown::classDropDown(classTile* tile, lv_event_cb_t dropDownEventHandler
   // configure the drop down 
   _dropDown = lv_dropdown_create(_panel);
   lv_obj_set_style_text_font(_dropDown, &lv_font_montserrat_20, 0);
-  lv_dropdown_set_options(_dropDown, "empty");
+  lv_obj_set_style_pad_ver(_dropDown, 18, LV_PART_MAIN);
   lv_obj_set_size(_dropDown, 300, LV_SIZE_CONTENT);
   lv_obj_align(_dropDown, LV_ALIGN_TOP_MID, 00, 10);
   lv_obj_set_style_border_width(_dropDown, 0, LV_PART_MAIN);
   lv_obj_set_style_bg_color(_dropDown, colorBg, LV_PART_MAIN);
   lv_obj_set_style_bg_opa(_dropDown, 150, LV_PART_MAIN);
+  lv_dropdown_set_options(_dropDown, "empty");
   lv_obj_t* list = lv_dropdown_get_list(_dropDown);
-  lv_obj_set_style_max_height(list, 400, LV_PART_MAIN);
+  lv_obj_set_style_max_height(list, 370, LV_PART_MAIN);
+  lv_obj_set_style_max_width(list, 300, LV_PART_MAIN);
   lv_obj_set_style_border_width(list, 0, LV_PART_MAIN);
+  lv_obj_set_style_text_line_space(list, 30, LV_PART_MAIN);
   lv_obj_set_style_text_font(list, &lv_font_montserrat_20, 0);
   lv_obj_set_style_bg_color(list, lv_color_hex(0xffffff), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(list, WP_OPA_BG_OFF, LV_PART_MAIN);
+  lv_obj_set_style_radius(list, 5, LV_PART_SELECTED);
   lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_PRESSED);
   lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_CHECKED);
 

--- a/src/classes/classDropDown.cpp
+++ b/src/classes/classDropDown.cpp
@@ -1,0 +1,99 @@
+﻿#include <classDropDown.h>
+#include <globalDefines.h>
+
+extern lv_color_t colorOn;
+extern lv_color_t colorBg;
+
+classDropDown::classDropDown(classTile* tile, lv_event_cb_t dropDownEventHandler)
+{
+  _callingTile = tile;
+
+  // full screen overlay / semi transparent
+  ovlPanel = lv_obj_create(lv_scr_act());
+  lv_obj_remove_style_all(ovlPanel);
+  lv_obj_set_size(ovlPanel, SCREEN_WIDTH, SCREEN_HEIGHT);
+  lv_obj_set_align(ovlPanel, LV_ALIGN_TOP_MID);
+  lv_obj_clear_flag(ovlPanel, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_style_bg_color(ovlPanel, colorBg, LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(ovlPanel, 150, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+  // active upper part / colorBg
+  _ovlPanel2 = lv_obj_create(ovlPanel);
+  lv_obj_remove_style_all(_ovlPanel2);
+  lv_obj_set_size(_ovlPanel2, SCREEN_WIDTH, SCREEN_HEIGHT - 35);
+  lv_obj_set_align(_ovlPanel2, LV_ALIGN_TOP_MID);
+  lv_obj_clear_flag(_ovlPanel2, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_style_bg_color(_ovlPanel2, colorBg, LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(_ovlPanel2, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+  // panel for active controls
+  lv_obj_t*  _panel = lv_obj_create(_ovlPanel2);
+  lv_obj_remove_style_all(_panel);
+
+  lv_obj_set_size(_panel, 310, SCREEN_HEIGHT - 35);
+  lv_obj_align(_panel, LV_ALIGN_TOP_MID, 0, 0);
+  lv_obj_clear_flag(_panel, LV_OBJ_FLAG_SCROLLABLE);
+
+  lv_obj_set_style_bg_color(_panel, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
+  lv_obj_set_style_bg_opa(_panel, WP_OPA_BG_OFF, LV_PART_MAIN | LV_STATE_DEFAULT);
+
+  // configure the dro down 
+  _dropDown = lv_dropdown_create(_panel);
+  lv_obj_set_style_text_font(_dropDown, &lv_font_montserrat_20, 0);
+  lv_dropdown_set_options(_dropDown, "empty");
+  lv_obj_set_size(_dropDown, 300, 40);
+  lv_obj_align(_dropDown, LV_ALIGN_TOP_MID, 00, 20);
+  lv_obj_set_style_border_width(_dropDown, 0, LV_PART_MAIN);
+  lv_obj_set_style_bg_color(_dropDown, colorBg, LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(_dropDown, 150, LV_PART_MAIN);
+  lv_obj_t* list = lv_dropdown_get_list(_dropDown);
+  lv_obj_set_style_text_font(list, &lv_font_montserrat_20, 0);
+  lv_obj_set_style_border_width(list, 0, LV_PART_MAIN);
+  lv_obj_set_style_bg_color(list, lv_color_hex(0xffffff), LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(list, WP_OPA_BG_OFF, LV_PART_MAIN);
+  lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_CHECKED);
+
+  // update with variables from calling tile
+  lv_dropdown_set_text(_dropDown, _callingTile->getDropDownLabel());
+  lv_dropdown_set_options(_dropDown, _callingTile->getDropDownList());
+  int index = _callingTile->getDropDownIndex();
+  if (index > 0) index--;
+  lv_dropdown_set_selected(_dropDown, index );
+
+  // add event handler
+  lv_obj_add_event_cb(_dropDown, dropDownEventHandler, LV_EVENT_ALL, _callingTile);
+}
+
+// open the list
+void classDropDown::open(void)
+{
+  lv_dropdown_open(_dropDown);
+}
+
+// close (destroy) the overlay panel
+void classDropDown::close(void)
+{
+  lv_obj_del(ovlPanel);
+}
+
+// populate drop down list
+void classDropDown::setDropDownList(const char* list)
+{
+  lv_dropdown_set_options(_dropDown, list);
+}
+
+// preset selected index
+void classDropDown::setDropDownIndex(uint16_t index)
+{
+  lv_dropdown_set_selected(_dropDown, index - 1);
+}
+
+// get reference of calling tile
+classTile* classDropDown::getTile(void)
+{
+  return _callingTile;
+}
+
+
+

--- a/src/classes/classDropDown.cpp
+++ b/src/classes/classDropDown.cpp
@@ -37,18 +37,19 @@ classDropDown::classDropDown(classTile* tile, lv_event_cb_t dropDownEventHandler
   lv_obj_set_style_bg_color(_panel, lv_color_hex(0xffffff), LV_PART_MAIN | LV_STATE_DEFAULT);
   lv_obj_set_style_bg_opa(_panel, WP_OPA_BG_OFF, LV_PART_MAIN | LV_STATE_DEFAULT);
 
-  // configure the dro down 
+  // configure the drop down 
   _dropDown = lv_dropdown_create(_panel);
   lv_obj_set_style_text_font(_dropDown, &lv_font_montserrat_20, 0);
   lv_dropdown_set_options(_dropDown, "empty");
-  lv_obj_set_size(_dropDown, 300, 40);
-  lv_obj_align(_dropDown, LV_ALIGN_TOP_MID, 00, 20);
+  lv_obj_set_size(_dropDown, 300, LV_SIZE_CONTENT);
+  lv_obj_align(_dropDown, LV_ALIGN_TOP_MID, 00, 10);
   lv_obj_set_style_border_width(_dropDown, 0, LV_PART_MAIN);
   lv_obj_set_style_bg_color(_dropDown, colorBg, LV_PART_MAIN);
   lv_obj_set_style_bg_opa(_dropDown, 150, LV_PART_MAIN);
   lv_obj_t* list = lv_dropdown_get_list(_dropDown);
-  lv_obj_set_style_text_font(list, &lv_font_montserrat_20, 0);
+  lv_obj_set_style_max_height(list, 400, LV_PART_MAIN);
   lv_obj_set_style_border_width(list, 0, LV_PART_MAIN);
+  lv_obj_set_style_text_font(list, &lv_font_montserrat_20, 0);
   lv_obj_set_style_bg_color(list, lv_color_hex(0xffffff), LV_PART_MAIN);
   lv_obj_set_style_bg_opa(list, WP_OPA_BG_OFF, LV_PART_MAIN);
   lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_PRESSED);
@@ -74,7 +75,7 @@ void classDropDown::open(void)
 // close (destroy) the overlay panel
 void classDropDown::close(void)
 {
-  lv_obj_del(ovlPanel);
+  lv_obj_del_delayed(ovlPanel, 50);
 }
 
 // populate drop down list

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -99,19 +99,23 @@ void classTile::_button(lv_obj_t *parent, const void *img)
 void classTile::_setIconTextFromIndex()
 {
   const char *text = lv_label_get_text(_dropDownList);
-  if (strlen(text) == 0)
-    return;
-
-  int index = _dropDownIndex;
-  if (index > 0)
-    index--;
-  lv_obj_t *dd = lv_dropdown_create(_btn);
-  lv_dropdown_set_options(dd, lv_label_get_text(_dropDownList));
-  lv_dropdown_set_selected(dd, index);
-  char buf[64];
-  lv_dropdown_get_selected_str(dd, buf, sizeof(buf));
-  setIconText(buf);
-  lv_obj_del(dd);
+  if (strlen(text) > 0)
+  {
+    int index = _dropDownIndex;
+    if (index > 0)
+      index--;
+    lv_obj_t *dd = lv_dropdown_create(_btn);
+    lv_dropdown_set_options(dd, text);
+    lv_dropdown_set_selected(dd, index);
+    char buf[64];
+    lv_dropdown_get_selected_str(dd, buf, sizeof(buf));
+    setIconText(buf);
+    lv_obj_del(dd);
+  }
+  else
+  {
+    setIconText("#ff0000 DropDown List empty#");
+  }
 }
 
 // recolor all effected objects

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -96,6 +96,24 @@ void classTile::_button(lv_obj_t *parent, const void *img)
   btn = _btn;
 }
 
+void classTile::_setIconTextFromIndex()
+{
+  const char *text = lv_label_get_text(_dropDownList);
+  if (strlen(text) == 0)
+    return;
+
+  int index = _dropDownIndex;
+  if (index > 0)
+    index--;
+  lv_obj_t *dd = lv_dropdown_create(_btn);
+  lv_dropdown_set_options(dd, lv_label_get_text(_dropDownList));
+  lv_dropdown_set_selected(dd, index);
+  char buf[64];
+  lv_dropdown_get_selected_str(dd, buf, sizeof(buf));
+  setIconText(buf);
+  lv_obj_del(dd);
+}
+
 // recolor all effected objects
 void classTile::_reColorAll(lv_color_t color, lv_style_selector_t selector)
 {
@@ -374,12 +392,14 @@ void classTile::showOvlBar(int level)
 void classTile::setDropDownList(const char *list)
 {
   lv_label_set_text(_dropDownList, list);
+  _setIconTextFromIndex();
 }
 
 // store selected item index
 void classTile::setDropDownIndex(uint16_t index)
 {
   _dropDownIndex = index;
+  _setIconTextFromIndex();
 }
 
 // store drop down label

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -358,3 +358,42 @@ void classTile::showOvlBar(int level)
 
   lv_obj_del_delayed(_ovlPanel, 2000);
 }
+
+// additional methods for on-tile level control
+
+// populate the drop down
+void classTile::setDropDownList(const char *list)
+{
+  if (lv_obj_is_valid(_dropDown))
+    lv_dropdown_set_options(_dropDown, list);
+}
+
+// select an item from the list (activate)
+// 1-based on UI
+void classTile::setSelectedItem(uint16_t index)
+{
+  if (index > 0) index--;
+  if (lv_obj_is_valid(_dropDown))
+    lv_dropdown_set_selected(_dropDown, index);
+}
+
+// add the DropDown
+void classTile::addDropDown(lv_event_cb_t dropDownEventHandler)
+{
+  _dropDown = lv_dropdown_create(_btn);
+  lv_dropdown_set_options(_dropDown, "Select");
+  int width = (*lv_obj_get_style_grid_column_dsc_array(_parent, 0) - 20);
+  lv_obj_set_size(_dropDown, width, 40);
+  lv_obj_align(_dropDown, LV_ALIGN_TOP_MID, 0, 5);
+  lv_obj_set_style_border_width(_dropDown, 0, LV_PART_MAIN);
+  lv_obj_set_style_bg_color(_dropDown, colorBg, LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(_dropDown, 150, LV_PART_MAIN);
+  lv_obj_t *list = lv_dropdown_get_list(_dropDown);
+  lv_obj_set_style_border_width(list, 0, LV_PART_MAIN);
+  lv_obj_set_style_bg_color(list, colorBg, LV_PART_MAIN);
+  lv_obj_set_style_bg_opa(list, 255, LV_PART_MAIN);
+  lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_PRESSED);
+  lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_CHECKED);
+
+  lv_obj_add_event_cb(_dropDown, dropDownEventHandler, LV_EVENT_ALL, this);
+}

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -72,6 +72,15 @@ void classTile::_button(lv_obj_t *parent, const void *img)
   lv_label_set_text(_txtIconText, "");
   lv_label_set_recolor(_txtIconText, true);
   lv_obj_add_flag(_txtIconText, LV_OBJ_FLAG_HIDDEN);
+ 
+  // placeholders for drop down
+  _dropDownList = lv_label_create(_btn);
+  lv_obj_add_flag(_dropDownList, LV_OBJ_FLAG_HIDDEN);
+  lv_label_set_text(_dropDownList, "");
+
+  _dropDownLabel = lv_label_create(_btn);
+  lv_obj_add_flag(_dropDownLabel, LV_OBJ_FLAG_HIDDEN);
+  lv_label_set_text(_dropDownLabel, "");
 
   // set button and label size from grid
   int width = *lv_obj_get_style_grid_column_dsc_array(parent, 0) - 10;
@@ -359,41 +368,48 @@ void classTile::showOvlBar(int level)
   lv_obj_del_delayed(_ovlPanel, 2000);
 }
 
-// additional methods for on-tile level control
+// additional methods for drop down (interface)
 
-// populate the drop down
+// store drop down list
 void classTile::setDropDownList(const char *list)
 {
-  if (lv_obj_is_valid(_dropDown))
-    lv_dropdown_set_options(_dropDown, list);
+  lv_label_set_text(_dropDownList, list);
 }
 
-// select an item from the list (activate)
-// 1-based on UI
-void classTile::setSelectedItem(uint16_t index)
+// store selected item index
+void classTile::setDropDownIndex(uint16_t index)
 {
-  if (index > 0) index--;
-  if (lv_obj_is_valid(_dropDown))
-    lv_dropdown_set_selected(_dropDown, index);
+  _dropDownIndex = index;
 }
 
-// add the DropDown
-void classTile::addDropDown(lv_event_cb_t dropDownEventHandler)
+// store drop down label
+void classTile::setDropDownLabel(const char *label)
 {
-  _dropDown = lv_dropdown_create(_btn);
-  lv_dropdown_set_options(_dropDown, "Select");
-  int width = (*lv_obj_get_style_grid_column_dsc_array(_parent, 0) - 20);
-  lv_obj_set_size(_dropDown, width, 40);
-  lv_obj_align(_dropDown, LV_ALIGN_TOP_MID, 0, 5);
-  lv_obj_set_style_border_width(_dropDown, 0, LV_PART_MAIN);
-  lv_obj_set_style_bg_color(_dropDown, colorBg, LV_PART_MAIN);
-  lv_obj_set_style_bg_opa(_dropDown, 150, LV_PART_MAIN);
-  lv_obj_t *list = lv_dropdown_get_list(_dropDown);
-  lv_obj_set_style_border_width(list, 0, LV_PART_MAIN);
-  lv_obj_set_style_bg_color(list, colorBg, LV_PART_MAIN);
-  lv_obj_set_style_bg_opa(list, 255, LV_PART_MAIN);
-  lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_PRESSED);
-  lv_obj_set_style_bg_color(list, colorOn, LV_PART_SELECTED | LV_STATE_CHECKED);
+  lv_label_set_text(_dropDownLabel, label);
+}
 
-  lv_obj_add_event_cb(_dropDown, dropDownEventHandler, LV_EVENT_ALL, this);
+// get the stored list
+const char *classTile::getDropDownList(void)
+{
+  return lv_label_get_text(_dropDownList);
+}
+
+// get the stored index
+uint16_t classTile::getDropDownIndex(void)
+{
+  return _dropDownIndex;
+}
+
+// get the stored label (NULL if "")
+const char *classTile::getDropDownLabel(void)
+{
+  if (strlen(lv_label_get_text(_dropDownLabel)) == 0)
+    return NULL;
+  else
+    return lv_label_get_text(_dropDownLabel);
+}
+
+void classTile::setDropDownIndicator(void)
+{
+  lv_label_set_text(_linkedLabel, LV_SYMBOL_DOWN);
 }

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -112,10 +112,6 @@ void classTile::_setIconTextFromIndex()
     setIconText(buf);
     lv_obj_del(dd);
   }
-  else
-  {
-    setIconText("#ff0000 DropDown List empty#");
-  }
 }
 
 // recolor all effected objects

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -480,7 +480,8 @@ static void dropDownEventHandler(lv_event_t *e)
 {
   lv_event_code_t code = lv_event_get_code(e);
   lv_obj_t *obj = lv_event_get_target(e);
-  if (code == LV_EVENT_VALUE_CHANGED)
+  // CANCEL fired when drop down list closed 
+  if (code == LV_EVENT_CANCEL)
   {
     classTile *tPtr = (classTile *)lv_event_get_user_data(e);
     tileId_t tileId = tPtr->getId();


### PR DESCRIPTION
New tile type "dropdown"

If this type is selected from the AdminUi no icon will be displayed. A dropdown selector box will be shown instead.
The default drop down list contains 1 entry `"Select"`.

To populate the drop down an additonal variable for the` cmnd/ setstate` is available
` cmnd/ '{"setstate":[{"screen":1, "tile":1, "dropdownlist":"Item1\nItem2\nItem3\nItem4"}]}'`
All single items of the drop down list (rows) have to seperated with `"\n"`.

To pre select a specific item from the list to synchronize the drop down with the HA/NR use 
` cmnd/ '{"setstate":[{"screen":1, "tile":1, "dropdownselect":2}]}'`
the` index is 1-based`. To select the 2nd item of the list set dropdownselect to 2.

When an item has been selected by the user an change event is sent
` stat/ {"screen":1,"tile":1,"type":"dropdown","event":"change","state":"Item3"}`


Please try this out and see how it feels, espcially on the wall, and give some feedback.

closes #19 
