### PR TITLE
image on tile

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,9 @@
     "list": "cpp",
     "array": "cpp",
     "string": "cpp",
-    "string_view": "cpp"
+    "string_view": "cpp",
+    "deque": "cpp",
+    "vector": "cpp",
+    "unordered_map": "cpp"
   }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "files.associations": {
-    "list": "cpp"
+    "list": "cpp",
+    "array": "cpp",
+    "string": "cpp",
+    "string_view": "cpp"
   }
 }

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -33,6 +33,8 @@ protected:
   bool _topDownMode = false;
   const void *_img = NULL;
   const void *_imgOn = NULL;
+  const void *_imgConfig = NULL;
+  const void *_imgOnConfig = NULL;
   uint16_t _dropDownIndex = 0;
 
   void _button(lv_obj_t *parent, const void *img);
@@ -57,6 +59,7 @@ public :
   void setColor(lv_color_t color);
   void setColor(int red, int green, int blue);
   void setColorToDefault(void);
+  void setIcon(const void *imgIcon);
   void setNumber(const char *number, const char *units);
   void setBgImage(lv_img_dsc_t *img, int zoom, int posOffsX, int posOffsY);
   void setLink(int linkedScreen);

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -25,7 +25,7 @@ protected:
   int _screenIdx = 0;
   int _tileIdx = 0;
   int _type = 0;
-  char _typeStr[16];
+  string _typeStr;
   int _linkedScreen = 0;
   bool _state = false;
   bool _keyPadEnable = false;
@@ -38,6 +38,7 @@ protected:
   void _button(lv_obj_t *parent, const void *img);
   void _reColorAll(lv_color_t color, lv_style_selector_t selector);
   void _setIconTextFromIndex(void);
+  void _freeImageHeap();
 
 public :
   tileId_t tileId;

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -58,7 +58,7 @@ public :
   void setColor(int red, int green, int blue);
   void setColorToDefault(void);
   void setNumber(const char *number, const char *units);
-  void setBgImage(const void*img, int zoom);
+  void setBgImage(lv_img_dsc_t *img, int zoom, int posOffsX, int posOffsY);
   void setLink(int linkedScreen);
   void setKeyPadEnable(bool enable);
   void setIconForStateOn(const void* imgStateOn);

--- a/include/classTile.h
+++ b/include/classTile.h
@@ -20,6 +20,7 @@ protected:
   lv_obj_t *_dropDown = NULL;
   lv_obj_t *_dropDownList = NULL;
   lv_obj_t *_dropDownLabel = NULL;
+  lv_obj_t *_imgBg = NULL;
 
   int _screenIdx = 0;
   int _tileIdx = 0;
@@ -56,6 +57,7 @@ public :
   void setColor(int red, int green, int blue);
   void setColorToDefault(void);
   void setNumber(const char *number, const char *units);
+  void setBgImage(const void*img, int zoom);
   void setLink(int linkedScreen);
   void setKeyPadEnable(bool enable);
   void setIconForStateOn(const void* imgStateOn);

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -15,6 +15,9 @@ void classTile::_button(lv_obj_t *parent, const void *img)
   // image button
   _btn = lv_imgbtn_create(_parent);
 
+  // placeholder for full image
+  _imgBg = lv_img_create(_btn);
+
   lv_imgbtn_set_src(_btn, LV_IMGBTN_STATE_RELEASED, img, NULL, NULL);
   lv_obj_set_style_bg_opa(_btn, WP_OPA_BG_OFF, LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
   lv_obj_set_style_img_recolor(_btn, lv_color_hex(0xffffff), LV_PART_MAIN | LV_IMGBTN_STATE_RELEASED);
@@ -221,6 +224,29 @@ void classTile::setNumber(const char *number, const char *units)
   lv_obj_set_style_text_font(_unitLabel, &lv_font_montserrat_20, 0);
   lv_label_set_text(_unitLabel, units);
   lv_obj_align_to(_unitLabel, _numLabel, LV_ALIGN_OUT_RIGHT_BOTTOM, 5, 5);
+}
+
+void classTile::setBgImage(const void *img, int zoom)
+{
+  if (zoom == 0)  zoom = 100;
+  if (zoom > 200) zoom = 200;
+  if (zoom < 50)  zoom = 50;
+
+  // free old image if exist
+  if (_imgBg)
+  {
+    lv_img_dsc_t *oldImg = (lv_img_dsc_t *)lv_img_get_src(_imgBg);
+    if (oldImg)
+    {
+      free((void*)oldImg->data);
+      free(oldImg);
+    }
+  }
+
+  lv_img_set_src(_imgBg, img);
+  lv_img_set_zoom(_imgBg, (256 * zoom) / 100);
+  lv_obj_align(_imgBg, LV_ALIGN_CENTER, 0, 00);
+  lv_obj_set_size(_imgBg, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
 }
 
 // this button calls a new screen (linkScreen)

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -125,6 +125,20 @@ void classTile::_reColorAll(lv_color_t color, lv_style_selector_t selector)
   lv_obj_set_style_text_color(_txtIconText, color, selector);
 }
 
+// free ps_ram heap used by old image if exist
+void classTile::_freeImageHeap(void)
+{
+  if (_imgBg)
+  {
+    lv_img_dsc_t *oldImg = (lv_img_dsc_t *)lv_img_get_src(_imgBg);
+    if (oldImg)
+    {
+      free((void *)oldImg->data);
+      free(oldImg);
+    }
+  }
+}
+
 classTile::classTile(lv_obj_t *parent, const void *img)
 {
   _button(parent, img);
@@ -140,6 +154,7 @@ classTile::~classTile()
 {
   if (_btn)
   {
+    _freeImageHeap();
     lv_obj_del(_btn);
   }
 }
@@ -159,7 +174,7 @@ void classTile::registerTile(int screenIdx, int tileIdx, int type, const char* t
   tileId.idx.screen = screenIdx;
   tileId.idx.tile = tileIdx;
   _type = type;
-  strcpy(_typeStr, typeStr);
+  _typeStr =  typeStr;
 
   // position tile in grid after tile and screen are known
   int row = (tileIdx - 1) / 2;
@@ -233,15 +248,7 @@ void classTile::setBgImage(const void *img, int zoom)
   if (zoom < 50)  zoom = 50;
 
   // free old image if exist
-  if (_imgBg)
-  {
-    lv_img_dsc_t *oldImg = (lv_img_dsc_t *)lv_img_get_src(_imgBg);
-    if (oldImg)
-    {
-      free((void*)oldImg->data);
-      free(oldImg);
-    }
-  }
+  _freeImageHeap();
 
   lv_img_set_src(_imgBg, img);
   lv_img_set_zoom(_imgBg, (256 * zoom) / 100);
@@ -293,7 +300,7 @@ int classTile::getType(void)
 
 const char* classTile::getTypeStr(void)
 {
-  return _typeStr;
+  return _typeStr.c_str();
 }
 
 bool classTile::getState(void)

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -11,6 +11,8 @@ void classTile::_button(lv_obj_t *parent, const void *img)
   _parent = parent;
   _img = img;
   _imgOn = img;
+  _imgConfig = img;
+  _imgOnConfig = img;
 
   // image button
   _btn = lv_imgbtn_create(_parent);
@@ -340,6 +342,24 @@ void classTile::setIconForStateOn(const void *imgStateOn)
   _imgOn = (imgStateOn != NULL) ? imgStateOn : _img;
   lv_imgbtn_set_src(_btn, LV_IMGBTN_STATE_CHECKED_RELEASED, _imgOn, NULL, NULL);
   lv_imgbtn_set_src(_btn, LV_IMGBTN_STATE_CHECKED_PRESSED, _imgOn, NULL, NULL);
+}
+
+// set icon for current state
+void classTile::setIcon(const void *imgIcon)
+{
+  if (lv_obj_get_state(_btn) & LV_STATE_CHECKED)
+  {
+    _imgOn = (imgIcon != NULL) ? imgIcon : _imgOnConfig;
+    lv_imgbtn_set_src(_btn, LV_IMGBTN_STATE_CHECKED_RELEASED, _imgOn, NULL, NULL);
+    lv_imgbtn_set_src(_btn, LV_IMGBTN_STATE_CHECKED_PRESSED, _imgOn, NULL, NULL);
+  }
+  else
+  {
+    _img = (imgIcon != NULL) ? imgIcon : _imgConfig;
+    lv_imgbtn_set_src(_btn, LV_IMGBTN_STATE_RELEASED, _img, NULL, NULL);
+    lv_imgbtn_set_src(_btn, LV_IMGBTN_STATE_PRESSED, _img, NULL, NULL);
+  }
+  lv_obj_invalidate(_btn);
 }
 
 // replaces the existing icon by selected text, reverts to icon if text is empty

--- a/src/classes/classTile.cpp
+++ b/src/classes/classTile.cpp
@@ -267,12 +267,12 @@ void classTile::setBgImage(lv_img_dsc_t *img, int zoom, int posOffsX, int posOff
   int imgH = (img->header.h * zoom) / 100;
   int tileW = lv_obj_get_width(_btn);
   int tileH = lv_obj_get_height(_btn);
-  if (posOffsX <= -100)    posOffsX = -(tileW / 2 - imgW / 2) - 1;
-  if (posOffsX >= 100)     posOffsX = (tileW / 2 - imgW / 2) + 1;
-  if (posOffsY <= -100)    posOffsY = -(tileH / 2 - imgH / 2) - 1;
-  if (posOffsY >= 100)     posOffsY = (tileH / 2 - imgH / 2) + 1;
+  if (posOffsX <= -100)    posOffsX = -(tileW / 2 - imgW / 2) - 1;    // left
+  if (posOffsX >= 100)     posOffsX = +(tileW / 2 - imgW / 2) + 1;    // right
+  if (posOffsY <= -100)    posOffsY = -(tileH / 2 - imgH / 2) - 1;    // bottom
+  if (posOffsY >= 100)     posOffsY = +(tileH / 2 - imgH / 2) + 1;    // top
 
-  lv_obj_align(_imgBg, LV_ALIGN_CENTER, posOffsX, posOffsY);
+  lv_obj_align(_imgBg, LV_ALIGN_CENTER, posOffsX, posOffsY * -1);
   lv_obj_set_style_radius(_imgBg, 5, 0);
   lv_obj_set_style_clip_corner(_imgBg, true, 0);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1233,6 +1233,11 @@ void jsonSetStateCommand(JsonVariant json)
     }
   }
 
+  if (json.containsKey("icon"))
+  {
+    tile->setIcon(iconVault.getIcon(json["icon"]));
+  }
+
   if (json.containsKey("number") || json.containsKey("units"))
   {
     tile->setNumber(json["number"], json["units"]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1290,13 +1290,25 @@ void jsonAddIcon(JsonVariant json)
   // decode image into ps_ram
   // TODO :
   //    check if ps_alloc successful
-  //    free allocated ps_ram if icon was deleted (replaced)
 
+  // check if named icon exist, if yes -> get descriptor
+  lv_img_dsc_t *oldIcon = (lv_img_dsc_t *)iconVault.getIcon(json["name"]);
+
+  // decode new icon
   lv_img_dsc_t *iconPng = decodeBase64ToImg(json["image"]);
 
-  // add custom icon to iconVault
+  // add custom icon to iconVault (deletes possible existing one)
   string iconStr = json["name"];
   iconVault.add({iconStr, iconPng});
+
+  // free ps_ram heap if named icon existed allready
+  if (oldIcon)
+  {
+    printf("before [icon del] %d\n", ESP.getFreePsram());
+    free((void *)oldIcon->data);
+    free(oldIcon);
+    printf("after [icon del] %d\n", ESP.getFreePsram());
+  }
 
   // update configutation 
   setConfigSchema();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1133,8 +1133,11 @@ lv_img_dsc_t *decodeBase64ToImg(const char *imageBase64)
   // decode image into ps_ram
   // TODO :
   //    check if ps_alloc successful
-  //    free allocated ps_ram if icon was deleted (replaced)
   size_t inLen = strlen(imageBase64);
+  // exit if no data to decode
+  if(inLen == 0)
+    return NULL;
+
   size_t outLen = BASE64::decodeLength(imageBase64);
   uint8_t *raw = (uint8_t *)ps_malloc(outLen);
   BASE64::decode(imageBase64, raw);
@@ -1241,7 +1244,7 @@ void jsonSetStateCommand(JsonVariant json)
 
   if (json.containsKey("image"))
   {
-    tile->setBgImage(decodeBase64ToImg(json["image"]), json["zoom"]);
+    tile->setBgImage(decodeBase64ToImg(json["image"]), json["zoom"], json["posOffset"][0], json["posOffset"][1]);
   }
 
   if (json.containsKey("dropdownlist"))
@@ -1304,10 +1307,8 @@ void jsonAddIcon(JsonVariant json)
   // free ps_ram heap if named icon existed allready
   if (oldIcon)
   {
-    printf("before [icon del] %d\n", ESP.getFreePsram());
     free((void *)oldIcon->data);
     free(oldIcon);
-    printf("after [icon del] %d\n", ESP.getFreePsram());
   }
 
   // update configutation 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -191,6 +191,7 @@ void initIconVault(void)
   iconVault.add({string("_speaker"), imgSpeaker});
   iconVault.add({string("_window"), imgWindow});
   iconVault.add({string("_3dprint"), img3dPrint});
+  iconVault.add({string("_onoff"), imgOnOff});
 }
 
 // initialise the tile_type_LUT


### PR DESCRIPTION
### EXPERIMENTAL feature

this allows to display a custom image on a tile.

`cmnd\  {"setstate":[{"screen":"1", "tile":"1", "image":"<encodeBase64(img.png)>", "zoom":"100"}]}`

`"image"; encodeBase64(image.png)  `    (size of the encoded image < 16k)
`"zoom": 50 ... 200 [%] `  scales the image
the image is centered within the destination tile
larger images will be cropped to the tile size

be aware : this is experimental !

